### PR TITLE
Standardize code replacement strings - Android quickstart

### DIFF
--- a/app/src/main/res/raw/auth_config.json
+++ b/app/src/main/res/raw/auth_config.json
@@ -1,7 +1,7 @@
 {
-  "client_id" : "Register your app at https://aka.ms/MobileAppReg",
+  "client_id" : "Enter_the_Application_Id_here",
   "authorization_user_agent" : "DEFAULT",
-  "redirect_uri" : "Register your app at https://aka.ms/MobileAppReg",
+  "redirect_uri" : "Enter_the_Redirect_URI_Here",
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
We have a working prototype to improve developer experience in quickstarts so that the downloaded code sample is ready-to-run and no longer needs manual step of copy-pasting the code blob with clientId/password/etc info. For that, we're standardizing code replacement strings as follows:
ClientIdStringToReplace : "Enter_the_Application_Id_here"
ClientTenantToReplace : "common"
ClientSecretToReplace": "Enter_the_Client_Secret_Here"
BundleIdToReplace : "Enter_the_Bundle_Id_Here"
RedirectUriToReplace : "Enter_the_Redirect_URI_Here"
PackageNameToReplace : "Enter_the_Package_Name_Here"
SignatureHashToReplace : "Enter_the_Signature_Hash_Here"
TypeToReplace: "AzureADandPersonalMicrosoftAccount"